### PR TITLE
Add rpy2 version 3.6.4 to environment

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -23,6 +23,7 @@ dependencies:
   - biopython=1.85
   - h5py=3.14.0
   - faiss=1.9.0
+  - rpy2=3.6.4
   - unzip
   - openjdk=8
 


### PR DESCRIPTION
rpy2 package needed to read Seurat Object (RDS) and extract phenotype info